### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/react-express-mongodb/backend/package.json
+++ b/react-express-mongodb/backend/package.json
@@ -21,7 +21,8 @@
     "mongodb": "^3.0.7",
     "mongoose": "^6.0.9",
     "simple-node-logger": "^18.12.23",
-    "validator": "^13.7.0"
+    "validator": "^13.7.0",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.3",

--- a/react-express-mongodb/backend/routes/index.js
+++ b/react-express-mongodb/backend/routes/index.js
@@ -2,9 +2,19 @@ const express = require("express");
 const serverResponses = require("../utils/helpers/responses");
 const messages = require("../config/messages");
 const { Todo } = require("../models/todos/todo");
+const rateLimit = require("express-rate-limit");
 
 const routes = (app) => {
   const router = express.Router();
+
+  // Set up rate limiter: maximum of 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  // Apply rate limiter to all requests
+  router.use(limiter);
 
   router.post("/todos", (req, res) => {
     const todo = new Todo({


### PR DESCRIPTION
Fixes [https://github.com/AKA-2025/studious-fiesta/security/code-scanning/5](https://github.com/AKA-2025/studious-fiesta/security/code-scanning/5)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the router handling the `/todos` and `/` routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
